### PR TITLE
Add configuration url

### DIFF
--- a/custom_components/dingz/__init__.py
+++ b/custom_components/dingz/__init__.py
@@ -113,6 +113,7 @@ class DingzEntity(CoordinatorEntity):
             "manufacturer": "iolo AG",
             "model": coordinator.device.front_hw_model,
             "sw_version": coordinator.info.version,
+            "configuration_url": f"http://{coordinator.info.ip}",
         }
 
     @property


### PR DESCRIPTION
Add a configuration url in order to easily navigate from the home assistant integration settings to the dingz web ui.