### PR TITLE
API v2 basic fixes

### DIFF
--- a/custom_components/dingz/api.py
+++ b/custom_components/dingz/api.py
@@ -145,8 +145,6 @@ class Sensors(FromJSON):
 
     If there is any error then this field contain null value.
     """
-    person_present: bool
-    """The current status of motion."""
     input_state: Optional[bool]
     """If the output 1 is not configured as input then the field contain null value otherwise bool value represent input state (the voltage present on input).
 
@@ -158,6 +156,9 @@ class Sensors(FromJSON):
     Each object contain the value field which show the current power provided to device connected to output.
     This field can have the null value in case of any failure.
     """
+    # API v1 only attributes
+    person_present: Optional[bool] = None
+    """API v1 only: The current status of motion."""
 
     room_temperature: Optional[float] = None
     """The compensated temperature in room.
@@ -193,10 +194,6 @@ class Sensors(FromJSON):
 class Thermostat(FromJSON):
     active: bool
     """If the thermostat functionality is enabled."""
-    out: int
-    """The output index assigned to thermostat."""
-    on: bool
-    """If the output controlled by thermostat is turn on."""
     enabled: bool
     """It the thermostat is enabled e.g. control output depending of temperature."""
     target_temp: float
@@ -209,6 +206,11 @@ class Thermostat(FromJSON):
     """Minimum target temperature."""
     max_target_temp: int
     """Maximum target temperature."""
+    # API v1 only attributes
+    out: Optional[int] = None
+    """API v1 only: The output index assigned to thermostat."""
+    on: Optional[bool] = None
+    """API v1 only: If the output controlled by thermostat is turn on."""
 
 
 @dataclasses.dataclass()

--- a/custom_components/dingz/api.py
+++ b/custom_components/dingz/api.py
@@ -384,12 +384,6 @@ class SystemConfig(FromJSON):
     """If it should be possible to enable WPS from the buttons."""
     allow_reboot: bool
     """If the restart should be possible from the buttons."""
-    broadcast_period: int
-    """How often to report a device to the network (5..65535).
-
-    Less broadcasting period causes the applications to find the device slower.
-    Unit is second.
-    """
     origin: bool
     """Whether the Origin HTTP header should be checked.
 
@@ -432,6 +426,13 @@ class SystemConfig(FromJSON):
     """Sets a Token for HTTP requests (max 256 chars).
 
     If the correct token is not provided, the query will be rejected.
+    """
+    # API v1 only attributes
+    broadcast_period: Optional[int] = 0
+    """API v1 only: How often to report a device to the network (5..65535).
+
+    Less broadcasting period causes the applications to find the device slower.
+    Unit is second.
     """
     mdns_search_period: Optional[int] = None
     groups: Optional[List[bool]] = None

--- a/tests/dingz/api/test_blind_config.py
+++ b/tests/dingz/api/test_blind_config.py
@@ -1,0 +1,57 @@
+import json
+
+from dingz.api import BlindConfig
+
+SAMPLE_RESPONSES = [
+    json.loads(
+        # API v2 response
+        """
+{
+  "blinds": [
+    {
+      "active": true,
+      "name": "Store Porte",
+      "type": "blind",
+      "min_value": 0,
+      "max_value": 100,
+      "def_blind": 0,
+      "def_lamella": 80,
+      "groups": "z",
+      "auto_calibration": true,
+      "shade_up_time": 55.65,
+      "shade_down_time": 55.21,
+      "invert_direction": false,
+      "lamella_time": 1.4,
+      "step_duration": 300,
+      "step_interval": 1200,
+      "state": "Initialised"
+    },
+    {
+      "active": true,
+      "name": "Store Fenêtre",
+      "type": "blind",
+      "min_value": 0,
+      "max_value": 100,
+      "def_blind": 0,
+      "def_lamella": 80,
+      "groups": "z",
+      "auto_calibration": true,
+      "shade_up_time": 47.55,
+      "shade_down_time": 47.02,
+      "invert_direction": false,
+      "lamella_time": 1.4,
+      "step_duration": 300,
+      "step_interval": 1200,
+      "state": "Initialised"
+    }
+  ]
+}
+"""
+    ),
+]
+
+
+def test_parse():
+    for response in SAMPLE_RESPONSES:
+        data = BlindConfig.list_from_json(response["blinds"])
+        assert len(data) == 2

--- a/tests/dingz/api/test_device.py
+++ b/tests/dingz/api/test_device.py
@@ -2,8 +2,9 @@ import json
 
 from dingz.api import Device
 
-SAMPLE_RESPONSE = json.loads(
-    """
+SAMPLE_RESPONSES = [
+    json.loads(
+        """
 {
   "ABCDEFA81XYZ": {
     "type": "dingz",
@@ -32,10 +33,50 @@ SAMPLE_RESPONSE = json.loads(
   }
 }
 """
-)
+    ),
+    json.loads(
+        # API v2 has apparently:
+        # + dip_misconf
+        # + dip_static
+        # + front_color
+        """
+  {
+  "ABCDEFA81XYZ": {
+    "type": "dingz",
+    "battery": false,
+    "reachable": true,
+    "meshroot": true,
+    "fw_version": "2.0.21",
+    "hw_version": "1.1.2",
+    "fw_version_puck": "2.1.4",
+    "bl_version_puck": "1.0.0",
+    "hw_version_puck": "1.1.2",
+    "hw_id_puck": 65535,
+    "puck_sn": "B20092900007",
+    "puck_production_date": {
+      "year": 20,
+      "month": 9,
+      "day": 29
+    },
+    "dip_config": 0,
+    "dip_static": false,
+    "dip_misconf": false,
+    "puck_hw_model": "DZ1B-4CH",
+    "front_hw_model": "dz1f-4b",
+    "front_production_date": "21/3/18",
+    "front_sn": "F21031800317",
+    "front_color": "WH",
+    "has_pir": false,
+    "hash": "a853cc0d"
+  }
+}
+"""
+    ),
+]
 
 
 def test_parse():
-    device_raw = next(iter(SAMPLE_RESPONSE.values()))
-    data = Device.from_json(device_raw)
-    assert data
+    for response in SAMPLE_RESPONSES:
+        device_raw = next(iter(response.values()))
+        data = Device.from_json(device_raw)
+        assert data

--- a/tests/dingz/api/test_state.py
+++ b/tests/dingz/api/test_state.py
@@ -2,8 +2,9 @@ import json
 
 from dingz.api import State
 
-SAMPLE_RESPONSE = json.loads(
-    """
+SAMPLE_RESPONSES = [
+    json.loads(
+        """
 {
   "dimmers": [
     {
@@ -111,9 +112,116 @@ SAMPLE_RESPONSE = json.loads(
   }
 }
 """
-)
+    ),
+    # API v2 state; has
+    # - sensors.person_present
+    json.loads(
+        """
+{
+  "dimmers": [],
+  "blinds": [
+    {
+      "moving": "stop",
+      "position": 100,
+      "lamella": 100,
+      "readonly": false,
+      "index": {
+        "relative": 0,
+        "absolute": 0
+      }
+    },
+    {
+      "moving": "stop",
+      "position": 100,
+      "lamella": 100,
+      "readonly": false,
+      "index": {
+        "relative": 1,
+        "absolute": 1
+      }
+    }
+  ],
+  "led": {
+    "on": false,
+    "hsv": "91;100;0",
+    "rgb": "FFFFFF",
+    "mode": "hsv",
+    "ramp": 25
+  },
+  "sensors": {
+    "brightness": 681,
+    "light_state": "day",
+    "light_state_lpf": "day",
+    "room_temperature": 25.5,
+    "uncompensated_temperature": 37.375,
+    "temp_offset": 6,
+    "cpu_temperature": 45,
+    "puck_temperature": 37,
+    "fet_temperature": 38,
+    "input_state": null,
+    "pirs": [
+      null,
+      {
+        "enabled": false,
+        "motion": false,
+        "mode": "idle",
+        "light_off_timer": 0,
+        "suspend_timer": 0
+      }
+    ],
+    "power_outputs": [
+      {
+        "value": 0
+      },
+      {
+        "value": 0
+      },
+      {
+        "value": 0
+      },
+      {
+        "value": 0
+      }
+    ]
+  },
+  "dyn_light": {
+    "mode": "day"
+  },
+  "thermostat": {
+    "active": false,
+    "state": "off",
+    "mode": "off",
+    "enabled": false,
+    "target_temp": 21,
+    "min_target_temp": 17,
+    "max_target_temp": 31,
+    "temp": 25.5
+  },
+  "wifi": {
+    "version": "2.0.21",
+    "mac": "F008D1C3A4F0",
+    "ssid": "HermineOriole",
+    "ip": "10.40.2.53",
+    "mask": "255.255.255.0",
+    "gateway": "10.40.2.1",
+    "dns": "10.40.2.1",
+    "static": false,
+    "connected": true
+  },
+  "cloud": {
+    "aws": "connected"
+  },
+  "time": "2023-06-16 17:19:46",
+  "config": {
+    "timestamp": 1686804173
+  }
+}
+"""
+    ),
+]
 
 
 def test_parse():
-    data = State.from_json(SAMPLE_RESPONSE)
-    assert data
+    for response in SAMPLE_RESPONSES:
+        data = State.from_json(response)
+        assert data

--- a/tests/dingz/api/test_system_config.py
+++ b/tests/dingz/api/test_system_config.py
@@ -2,8 +2,9 @@ import json
 
 from dingz.api import SystemConfig
 
-SAMPLE_RESPONSE = json.loads(
-    """
+SAMPLE_RESPONSES = [
+    json.loads(
+        """
 {
   "allow_reset": true,
   "allow_wps": true,
@@ -46,9 +47,64 @@ SAMPLE_RESPONSE = json.loads(
   "system_status": "OK"
 }
 """
-)
+    ),
+    json.loads(
+        # API v2 has at least :
+        # - broadcast_period less
+        """
+{
+  "protected_status": false,
+  "allow_reset": true,
+  "allow_wps": true,
+  "allow_reboot": true,
+  "allow_remote_reboot": false,
+  "origin": true,
+  "upgrade_blink": true,
+  "reboot_blink": false,
+  "dingz_name": "dingz",
+  "room_name": "Cuisine",
+  "id": "f008d1c3a4f0",
+  "temp_offset": 6,
+  "fet_offset": 2.5,
+  "cpu_offset": 26.4,
+  "temp_comp": {
+    "fet_offset": 2.64,
+    "gain_up": 0.012,
+    "gain_down": 0.006,
+    "gain_total": 0.25
+  },
+  "sun_offset": 0,
+  "tzid": 0,
+  "lat": 10.0000,
+  "long": 0.1234,
+  "dyn_light": {
+    "enable": true,
+    "phases": 3,
+    "source": "sun",
+    "sun_offset": {
+      "day": 30,
+      "twilight": 30,
+      "night": 30
+    }
+  },
+  "wifi_ps": true,
+  "time": "2023-06-16 17:15:10",
+  "sunrise": {
+    "hour": 5,
+    "minute": 36
+  },
+  "sunset": {
+    "hour": 21,
+    "minute": 27
+  },
+  "system_status": "OK"
+}
+"""
+    ),
+]
 
 
 def test_parse():
-    data = SystemConfig.from_json(SAMPLE_RESPONSE)
-    assert data
+    for response in SAMPLE_RESPONSES:
+        data = SystemConfig.from_json(response)
+        assert data


### PR DESCRIPTION
Hello there @siku2 .

Here come the initial works to get the dingz working after a firmware upgrade to the 2.x firmware: I've mostly crammed excerpts from the only Dingz device I have here in the tests, and moved around the arguments that were no longer fed.

This doesn't cover much new functionality, but at least restores local reading and POSTing.

Could you perhaps release a 0.2.0 with that?

Do you want to keep supporting both firmware versions?